### PR TITLE
set CC_TEST_REPORTER_ID

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
       - name: mypy type check
         uses: tsuyoshicho/action-mypy@v3
         with:
-          github_token: '${{ secrets.github_token }}'
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
           reporter: github-pr-review
           mypy_flags: '--config-file=pm-coding-template/mypy.ini'
       - name: Install dependencies
@@ -146,7 +146,7 @@ jobs:
       - name: Test & publish code coverage
         uses: paambaati/codeclimate-action@v2.7.5
         env:
-          CC_TEST_REPORTER_ID: 6111e4d3e0e37e69d0142c9f9e57ecf88ff79b2718339e75ff30d946469c9b8e
+          CC_TEST_REPORTER_ID: '${{ secrets.CC_TEST_REPORTER_ID }}'
         with:
           coverageCommand: coverage report
       - name: Check missing docstrings - interrogate


### PR DESCRIPTION
* I regenerated reporter id so old value is not 
dangerous when we make repo public
* I set new value as value of CC_TEST_REPORTER_ID secret

* now the workflow says `CC_TEST_REPORTER_ID: '${{ secrets.CC_TEST_REPORTER_ID }}'` which i think is better
* I also capitalized secrets.GITHUB_TOKEN elsewhere -- btw per https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions. github.token is "functionally equivalent" -- we can change to that if that seems somehow more intuitive that it's not something the user needs to set

### Related issues

- Issues goes here

### Submissions

- [ ] Have you followed the guidelines in our [Contributing document](https://github.com/predictionmachine/pm-coding-template)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Test cases and other details

- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

- **Other information**:
