### PR TITLE
Fix CI build pass for empty PR description

### DIFF
--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -27,7 +27,7 @@ jobs:
     name: 'Check PR description, fail if empty'
     env:
       GUIDELINE_REPO: 'https://github.com/predictionmachine/pm-coding-template'
-      TEMPLATE_URL: 'https://github.com/predictionmachine/pm-coding-template/blob/main/PULL_REQUEST_TEMPLATE.md'
+      TEMPLATE_URL: 'https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md'
     steps:
       - name: Check PR description
         if: ${{ github.event_name == 'pull_request' }}
@@ -38,17 +38,20 @@ jobs:
           echo ${PR_BODY:0:5}
           if [ "${PR_BODY:0:5}" == "" ];then
             echo "::set-output name=is_empty_body::true"
-          else
-            exit 0
           fi
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ steps.getPrBody.outputs.is_empty_body == 'true' }}
         with:
-          header: pr-check
+          header: pr-empty-comments
           message: |
             👋 &nbsp; @${{ github.event.pull_request.user.login }}
-            Please use the PR template mentioned [here]($TEMPLATE_URL)
-            Please make sure you have followed our [contributing guidelines]($GUIDELINE_REPO).
+            Please use the PR template mentioned [here](${{ env.TEMPLATE_URL }})
+            Please make sure you have followed our [contributing guidelines](${{ env.GUIDELINE_REPO }}).
+      - name: Exit the job for empty PR description
+        if: ${{ steps.getPrBody.outputs.is_empty_body == 'true' }}
+        run: |
+          echo "Failed due to empty PR description"
+          exit 1
 
   check-unwanted-files:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Related issues

- Fixes #12 
- Added step to fail the CI build if PR description is empty
- Fix ENV usage of - `TEMPLATE_URL` & `GUIDELINE_REPO`

### Submissions

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/predictionmachine/pm-coding-template)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Test cases and other details

- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Other Information**:
