### PR TITLE
drop `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,0 @@
-.git
-.gitignore
-node_modules
-npm-debug.log
-Dockerfile*
-docker-compose*
-README.md
-LICENSE
-.vscode


### PR DESCRIPTION
The file `.dockerignore` is not needed in this repo and is removed