### PR TITLE
launch pytest with `python -m pytest`

### DIFF
--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -2,7 +2,7 @@
 # Copyright (C) 2021 Prediction Machine Advisers, LLC
 # This file is available under MIT license
 # based on https://github.com/predictionmachine/pm-gh-actions/blob/main/.github/workflows/pm-gh-actions.yml
-# pm-version 0.3.5
+# pm-version 0.3.5.1
 ############################################################################################
 
 name: PM CI workflow
@@ -250,7 +250,7 @@ jobs:
       - name: Test with pytest and generate cov
         # see also https://pytest-cov.readthedocs.io/en/latest/config.html
         run: |
-          pytest --cov-report xml:$COVERAGE_OUTPUT_PATH --cov=. --cov-config=setup.cfg \
+          python -m pytest --cov-report xml:$COVERAGE_OUTPUT_PATH --cov=. --cov-config=setup.cfg \
             --continue-on-collection-errors --no-cov-on-fail
       - name: Upload code coverage to codeclimate
         uses: paambaati/codeclimate-action@v2.7.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,8 @@
-# pm-version 0.1.1
+# pm-version 0.1.4
+[coverage:run]
+# https://coverage.readthedocs.io/en/latest/config.html
+omit = tests/*
+
 [flake8]
 # see https://flake8.pycqa.org/en/latest/user/options.html#options-list
 exclude =
@@ -20,5 +24,6 @@ warn_return_any = True
 warn_unused_configs = True
 warn_unused_ignores = True
 pretty = True
+
 [mypy-numpy,pandas.*,pyarrow.*,pytest.*,pytest_mock,setuptools]
 ignore_missing_imports = True


### PR DESCRIPTION
use `python -m pytest` in pm-gh-actions.yml

What functionality does this add/problem does this address?
bumps setup.cfg to include latest pytest-cov config, and fixes regression caused by launching pytest improperly (it does not get correct . in  pythonpath).

This is a small change.

## Checklist
- [x] Does the PR have an informative, carefully chosen **title**?
- [x] Updated README.md and inline documentation as appropriate
- [x] New files have copyright statement at the top and a careful, useful description of what the file does
- [x] Have you followed the other [Coding standards](https://github.com/predictionmachine/pm-coding-template#code-contents)?
- [x] Applied *labels* to the PR

<!-- version 0.3.1 -->
<!-- based on https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md -->
