### PR TITLE
fix links to repo after repo rename to `pm-github-actions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # A Helpful GitHub Actions Workflow
+[![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/)
 [![PM CI workflow](https://github.com/predictionmachine/pm-coding-template/actions/workflows/pm-gh-actions.yml/badge.svg)](https://github.com/predictionmachine/pm-coding-template/actions/workflows/pm-gh-actions.yml)
-<!-- see https://app.codecov.io/gh/predictionmachine/pm-gh-actions/settings/badge -->
-[![codecov](https://codecov.io/gh/predictionmachine/pm-gh-actions/branch/main/graph/badge.svg?token=2AQW1NP110)](https://codecov.io/gh/predictionmachine/pm-gh-actions)
+<!-- see https://app.codecov.io/gh/predictionmachine/pm-github-actions/settings/badge -->
+[![codecov](https://codecov.io/gh/predictionmachine/pm-github-actions/branch/main/graph/badge.svg?token=2AQW1NP110)](https://codecov.io/gh/predictionmachine/pm-github-actions)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 This repository provides a **GitHub Actions [workflow](.github/workflows/pm-gh-actions.yml)** to check and nicely comment on
@@ -168,4 +169,5 @@ If you want to pass additional args, change location of config file, proceed as 
  For more details please see [reviewdog/action-detect-secrets](https://github.com/reviewdog/action-detect-secrets) and [detect-secrets](https://github.com/Yelp/detect-secrets)
 
 - - -
-Developed and used by _Prediction Machine_.
+<!-- TODO: update to new website when ready -->
+Developed and used by [Prediction Machine](https://github.com/predictionmachine).


### PR DESCRIPTION
## Description

What functionality does this add/problem does this address?
some links were broken, now they are not.
Also adds a "License:MIT" badge, and link to  PM Website a the bottom
 
This is a small change.

## Checklist
- [x] Does the PR have an informative, carefully chosen **title**?
- [x] Updated README.md and inline documentation as appropriate
- [x] New files have copyright statement at the top and a careful, useful description of what the file does
- [x] Have you followed the other [Coding standards](https://github.com/predictionmachine/pm-coding-template#code-contents)?
- [x] Applied *labels* to the PR

<!-- version 0.3.1 -->
<!-- based on https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md -->
