### PR TITLE
Fix `mypy` CI step

### DIFF
--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -2,7 +2,7 @@
 # Copyright (C) 2021 Prediction Machine Advisers, LLC
 # This file is available under MIT license
 # based on https://github.com/predictionmachine/pm-github-actions/blob/main/.github/workflows/pm-gh-actions.yml
-# pm-version 0.3.6.1
+# pm-version 0.3.7
 ############################################################################################
 
 name: PM CI workflow
@@ -213,16 +213,23 @@ jobs:
           exit 1
 
   mypy-typecheck:
-    name: 'Mypy Type check'
-    runs-on: ubuntu-latest
     timeout-minutes: 30
+    runs-on: ubuntu-latest
+    name: 'Mypy Type check'
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
       - name: mypy type check
-        uses: tsuyoshicho/action-mypy@v3
+        uses: tsuyoshicho/action-mypy@v3.0.1
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           reporter: github-pr-review
           mypy_flags: '--config-file=setup.cfg'
+          fail_on_error: true
 
   test-and-coverage:
     name: 'Pytest and Coverage'


### PR DESCRIPTION
## Description
ClickUp [task](https://app.clickup.com/t/y1brvm)

What functionality does this add/problem does this address?
mypy check was silently failng b/c code was not checked out and it did not have fail on exit set

This is a small change to `pm-gh-actions.yml`

## Checklist
- [x] Does the PR have an informative, carefully chosen **title**?
- [x] Updated README.md and inline documentation as appropriate
- [x] New files have copyright statement at the top and a careful, useful description of what the file does
- [x] Have you followed the other [Coding standards](https://github.com/predictionmachine/pm-coding-template#code-contents)?
- [x] Applied *labels* to the PR

<!-- version 0.3.1 -->
<!-- based on https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md -->
