### PR TITLE
install dependencies so mypy CI works

### DIFF
--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -2,7 +2,7 @@
 # Copyright (C) 2021 Prediction Machine Advisers, LLC
 # This file is available under MIT license
 # based on https://github.com/predictionmachine/pm-github-actions/blob/main/.github/workflows/pm-gh-actions.yml
-# pm-version 0.3.7
+# pm-version 0.3.8
 ############################################################################################
 
 name: PM CI workflow

--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -223,6 +223,20 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - name: Use cache if possible
+        # see [cache](https://github.com/actions/cache) and
+        # [pip example](https://github.com/actions/cache/blob/master/examples.md#simple-example))
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements**.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - name: mypy type check
         uses: tsuyoshicho/action-mypy@v3.0.1
         with:


### PR DESCRIPTION
## Description
ClickUp [task](https://app.clickup.com/t/y1brvm)

What functionality does this add/problem does this address?
still just running mypy correctly.
turns out we need to install dependencies in order for it to work
in cases where stubs and annotated libs need to be available for analysis

This is a small change.

## Checklist
- [x] Does the PR have an informative, carefully chosen **title**?
- [x] Updated README.md and inline documentation as appropriate
- [x] New files have copyright statement at the top and a careful, useful description of what the file does
- [x] Have you followed the other [Coding standards](https://github.com/predictionmachine/pm-coding-template#code-contents)?
- [x] Applied *labels* to the PR

<!-- version 0.3.1 -->
<!-- based on https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md -->
