### PR TITLE
Remove coverage config from setup.cfg & update coverage action step

### DIFF
--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -2,7 +2,7 @@
 # Copyright (C) 2021 Prediction Machine Advisers, LLC
 # This file is available under MIT license
 # based on https://github.com/predictionmachine/pm-github-actions/blob/main/.github/workflows/pm-gh-actions.yml
-# pm-version 0.3.9
+# pm-version 0.3.10
 ############################################################################################
 
 name: PM CI workflow
@@ -277,7 +277,7 @@ jobs:
       - name: Test with pytest and generate cov
         # see also https://pytest-cov.readthedocs.io/en/latest/config.html
         run: |
-          python -m pytest --cov-report xml:$COVERAGE_OUTPUT_PATH --cov=. --cov-config=setup.cfg \
+          python -m pytest --cov-report xml:$COVERAGE_OUTPUT_PATH --cov=. --cov-config=pyproject.toml \
             --continue-on-collection-errors --no-cov-on-fail
       - name: Upload code coverage to codeclimate
         uses: paambaati/codeclimate-action@v2.7.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,4 @@
-# pm-version 0.1.5
-[coverage:run]
-# https://coverage.readthedocs.io/en/latest/config.html
-omit = tests/*
+# pm-version 0.1.6
 
 [flake8]
 # see https://flake8.pycqa.org/en/latest/user/options.html#options-list


### PR DESCRIPTION
## Description
ClickUp [task](https://app.clickup.com/t/3zdv0b)

What functionality does this add/problem does this address?
- Remove coverage config from setup.cfg and update the same in action's coverage step

This is a small change.

- [ ] This PR part of a larger effort
        - what will be addressed in separate PRs?

Have you added <!--keep relevant items-->:
- [ ] TODO comments about the work not shipped in this PR
- [ ] TODO comments about nice to have refactoring
- [ ] doc strings and comments about design decisions and approach taken/not taken


## Checklist
- [x] Does the PR have an informative, carefully chosen **title**?
- [ ] Updated README.md and inline documentation as appropriate
- [ ] New files have copyright statement at the top and a careful, useful description of what the file does
- [x] Have you followed the other [Coding standards](https://github.com/predictionmachine/pm-coding-template#code-contents)?
- [X] Applied *labels* to the PR

<!-- version 0.3.1 -->
<!-- based on https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md -->