### PR TITLE
Feature: Add org-wide (resuable workflow) to be used by other repo workflow's

### DIFF
--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -11,8 +11,10 @@ on:
     secrets:
       CC_TEST_REPORTER_ID:
         description: 'a repo-specific test reporter id provided by Codeclimate for submitting coverage report'
+        required: true
       CODECOV_TOKEN:
         description: 'a repo-specific token for uploading coverage reports to Codcov'
+        required: true
   push:
     branches:
       - dev
@@ -30,14 +32,14 @@ env:
 
 jobs:
   # Check branch name standard as per `pm-coding-template`
-  # Ref: https://github.com/predictionmachine/pm-coding-template#github-branches-pull-requests
+  # Reference: https://github.com/predictionmachine/pm-coding-template/blob/main/docs/coding-standard.md#github-branches-pull-requests
   check-branch-naming-convention:
     name: Check branch naming convention as per pm-coding-template
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.event_name == 'pull_request' }}
     env:
-      BRANCH_NAME_RULE: 'https://github.com/predictionmachine/pm-coding-template#github-branches-pull-requests'
+      BRANCH_NAME_RULE: 'https://github.com/predictionmachine/pm-coding-template/blob/main/docs/coding-standard.md#github-branches-pull-requests'
     steps:
       - name: Check branch name
         id: branchCheck
@@ -68,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      TEMPLATE_URL: 'https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md'
+      TEMPLATE_URL: 'https://github.com/predictionmachine/.github/blob/main/.github/pull_request_template.md'
     steps:
       - name: Check PR description
         if: ${{ github.event_name == 'pull_request' }}
@@ -123,6 +125,22 @@ jobs:
             Please remove unwanted files from the repo.
             Here is the detected file path: ${{ steps.fileCheck.outputs.file_paths }}
             Please make sure you have followed our [contributing guidelines](${{ env.GUIDELINE_REPO }}).
+
+  # see [reviewdog/action-detect-secrets](https://github.com/Yelp/detect-secrets) and
+  # [detect-secrets](https://github.com/Yelp/detect-secrets)
+  check-hardcoded-credentials:
+    name: Check hardcoded credentials in files
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: detect-secrets
+        uses: reviewdog/action-detect-secrets@master
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+          reporter: github-pr-review
+          fail_on_error: false
 
   linting:
     name: 'Linting: black, flake8'

--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -2,11 +2,17 @@
 # Copyright (C) 2021 Prediction Machine Advisers, LLC
 # This file is available under MIT license
 # based on https://github.com/predictionmachine/pm-github-actions/blob/main/.github/workflows/pm-gh-actions.yml
-# pm-version 0.3.10
+# pm-version 0.4.0
 ############################################################################################
 
 name: PM CI workflow
 on:
+  workflow_call:  # enables this workflow to be reusable for other repo. See: https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
+    secrets:
+      CC_TEST_REPORTER_ID:
+        description: 'a repo-specific test reporter id provided by Codeclimate for submitting coverage report'
+      CODECOV_TOKEN:
+        description: 'a repo-specific token for uploading coverage reports to Codcov'
   push:
     branches:
       - dev
@@ -16,7 +22,6 @@ on:
       - opened
       - edited
       - reopened
-      - synchronize
     branches:
       - main
       - dev
@@ -119,22 +124,6 @@ jobs:
             Here is the detected file path: ${{ steps.fileCheck.outputs.file_paths }}
             Please make sure you have followed our [contributing guidelines](${{ env.GUIDELINE_REPO }}).
 
-  # see [reviewdog/action-detect-secrets](https://github.com/Yelp/detect-secrets) and
-  # [detect-secrets](https://github.com/Yelp/detect-secrets)
-  check-hardcoded-credentials:
-    name: Check hardcoded credentials in files
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: detect-secrets
-        uses: reviewdog/action-detect-secrets@master
-        with:
-          github_token: '${{ secrets.GITHUB_TOKEN }}'
-          reporter: github-pr-review
-          fail_on_error: true
-
   linting:
     name: 'Linting: black, flake8'
     runs-on: ubuntu-latest
@@ -192,7 +181,7 @@ jobs:
           echo "::set-output name=passed_or_failed::$passed_or_failed"
       - name: Reformat docstring report
         run: |
-          sed -i "s!^=.*!## Docstring Coverage :memo:!" "$DOCSTRING_REPORT"
+          sed -i "s!^==*!## Docstring Coverage :memo:!" "$DOCSTRING_REPORT"
           sed -i "s!.*-- Summary --.*!\n<details><summary>docstring coverage details</summary>\n!" "$DOCSTRING_REPORT"
           sed -i "s!.*-- RESULT:!</details>\n\n!" "$DOCSTRING_REPORT"
           sed -i "s!) --.*!)!" "$DOCSTRING_REPORT"
@@ -238,14 +227,16 @@ jobs:
           python -m pip install --upgrade pip
           if [ requirements.txt ]; then pip install -r requirements.txt; fi
           if [ requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-      - name: mypy type check
+      - name: mypy type check - reviewdog
         uses: tsuyoshicho/action-mypy@v3
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
-          level: info
           reporter: github-pr-review
-          # mypy_flags: '--config-file=pyproject.toml'
-          fail_on_error: true
+          level: warning  # to prevent failing without error
+          # fail_on_error: true
+      - name: mypy type check
+        run: |
+          python -m mypy
 
   test-and-coverage:
     name: 'Pytest and Coverage'
@@ -275,7 +266,7 @@ jobs:
           if [ requirements.txt ]; then pip install -r requirements.txt; fi
           if [ requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - name: Test with pytest and generate cov
-        # see also https://pytest-cov.readthedocs.io/en/latest/config.html
+        # see also https://pytest-cov.readthedocs.io/en/latest/config.html#caveats
         run: |
           python -m pytest --cov-report xml:$COVERAGE_OUTPUT_PATH --cov=. --cov-config=pyproject.toml \
             --continue-on-collection-errors --no-cov-on-fail

--- a/README.md
+++ b/README.md
@@ -54,8 +54,31 @@ The expected layout is:
 ## Installation:
 
 - Copy and paste
-  [pm-gh-actions.yml](.github/workflows/pm-gh-actions.yml) and relevant config files
-  into your repo.
+  [pm-gh-actions.yml](.github/workflows/pm-gh-actions.yml) and relevant config files. OR call this workflow as one of the jobs under your repo's workflow - this workflow is [reusable workflow](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows), so you can call this from your workflow as followed:
+
+  ```YAML
+  # file: caller_workflow_name.yaml
+
+  name: CI workflow
+  on:
+    push:
+      branches:
+        - main
+    pull_request:
+      types:
+        - opened
+      branches:
+        - main
+
+  jobs:
+    # reference: https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#example-caller-workflow
+    org-checks:
+      uses: predictionmachine/pm-github-actions/.github/workflows/pm-gh-actions.yml@main
+      secrets:
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  ```
+
 - Set a couple of secrets:
   - `CC_TEST_REPORTER_ID` (a repo-specific id provided by Codeclimate)
   See [finding your test coverage token](https://docs.codeclimate.com/docs/finding-your-test-coverage-token).
@@ -68,7 +91,7 @@ The expected layout is:
 
   It's a good idea to invoke the configured linting tools locally prior to creating the PR.
   ProTip: it is likely you can configure them in your IDE.
-  
+
   You can also configure and use [pre-commit hooks](https://pre-commit.com/#plugins). \
   Copy [.pre-commit-config.yaml](.pre-commit-config.yaml) to the root directory of your repo and follow the [installation](https://pre-commit.com/#installation) instructions to run it.
 
@@ -175,5 +198,5 @@ If you want to pass additional args, change location of config file, proceed as 
  For more details please see [reviewdog/action-detect-secrets](https://github.com/reviewdog/action-detect-secrets) and [detect-secrets](https://github.com/Yelp/detect-secrets)
 
 - - -
-<!-- TODO: update to new website when ready -->
-Developed and used by [Prediction Machine](https://github.com/predictionmachine).
+
+Developed and used by [Prediction Machine](https://predmachine.com/).


### PR DESCRIPTION


## Description
DEV-296<!-- replace this with task id, leaving eg DEV-123 -->
- Add  `workflow_call` to make workflow reusable in another repo workflow. See [reusing workflow](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows)
- Set `fail-on-error` flag to false for reviewdog/action-detect-secrets job

<!--link to issue or description: Issue #-->
<!--What functionality does this add/problem does this fix?-->

This is a <!--choose one: --> 🐁 change.  <!--🐁:small, 🐕:medium, 🐘:large -->
<!-- add advice on what files to start the review with, where complex code is -->

<!-- uncomment below if it's true, delete otherwise -->
<!--
This PR part of a larger effort:
  - --> <!-- describe what will be addressed in separate PRs -->

## Checklist
- [x] Set an informative, carefully chosen **title**
- [x] Applied *labels* to the PR
- [x] Updated README.md and inline documentation as appropriate
- [x] Followed [Coding standards](https://github.com/predictionmachine/pm-coding-template/blob/main/docs/coding-standard.md#coding-standard)
- [ ] Added TODO comments about the work not shipped in this PR
- [ ] Documented bugs/issues you had to work around

<!-- version 0.4.1 -->
<!-- based on https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md -->
